### PR TITLE
Add PR trigger and improve Psalm version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,6 @@
 name: CI
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
   phpunit:

--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,7 @@
         "giorgiosironi/eris": "^0.11.0",
         "innmind/file-watch": "~2.0",
         "innmind/operating-system": "^2.0",
-        "vimeo/psalm": "~3.7.0"
+        "vimeo/psalm": "^3.7"
     },
     "scripts": {
         "test": "vendor/bin/phpunit --colors=always"


### PR DESCRIPTION
# Changed log
- Add `pull_request` trigger on GitHub action.
- To install latest Psalm version, it should define `^3.7` for `psalm` dependency.